### PR TITLE
Fixed Wrong action on cancel (#31)

### DIFF
--- a/src/Edit.NET/ViewModels/EditorViewModel.cs
+++ b/src/Edit.NET/ViewModels/EditorViewModel.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using AvaloniaEdit.Document;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Consolonia.Controls;
 using EditNET.DataModels;
 using JetBrains.Annotations;
 using ReactiveUI;
@@ -35,7 +36,7 @@ namespace EditNET.ViewModels
             _settings = new Settings();
         }
 
-        public Interaction<MessageBoxModel, bool> MessageBoxInteraction { get; } = new();
+        public Interaction<MessageBoxModel, MessageBoxResult> MessageBoxInteraction { get; } = new();
         public Interaction<Unit, Unit> FocusEditorInteraction { get; } = new();
         public Interaction<Unit, string?> OpenFileInteraction { get; } = new();
         public Interaction<Unit, string?> SaveFileInteraction { get; } = new();
@@ -64,7 +65,10 @@ namespace EditNET.ViewModels
         public async Task NewCommand()
         {
             if (!await CheckSaved())
+            {
+                await FocusEditorInteraction.Handle(Unit.Default);
                 return;
+            }
 
             Document = new TextDocument();
             FilePath = null;
@@ -75,11 +79,17 @@ namespace EditNET.ViewModels
         public async Task OpenCommand()
         {
             if (!await CheckSaved())
+            {
+                await FocusEditorInteraction.Handle(Unit.Default);
                 return;
+            }
 
             string? filePath = await OpenFileInteraction.Handle(Unit.Default);
             if (filePath == null)
+            {
+                await FocusEditorInteraction.Handle(Unit.Default);
                 return;
+            }
 
             await OpenFile(Path.GetFullPath(filePath));
 
@@ -110,7 +120,11 @@ namespace EditNET.ViewModels
         public async Task ExitCommand()
         {
             if (!await CheckSaved())
+            {
+                await FocusEditorInteraction.Handle(Unit.Default);
                 return;
+            }
+
             await ShutdownInteraction.Handle(Unit.Default);
         }
 
@@ -151,10 +165,13 @@ namespace EditNET.ViewModels
             if (!Modified)
                 return true;
 
-            bool shouldSave = await MessageBoxInteraction.Handle(new MessageBoxModel("Unsaved Changes",
+            MessageBoxResult shouldSave = await MessageBoxInteraction.Handle(new MessageBoxModel("Unsaved Changes",
                 "You have unsaved changes. Do you want to save them?", MessageBoxButtons.YesNo));
 
-            if (!shouldSave)
+            if (shouldSave == MessageBoxResult.Cancel)
+                return false;
+
+            if (shouldSave == MessageBoxResult.No)
                 return true;
 
             await SaveCommand();

--- a/src/Edit.NET/Views/EditorView.axaml.cs
+++ b/src/Edit.NET/Views/EditorView.axaml.cs
@@ -125,7 +125,7 @@ namespace EditNET.Views
                     await storageProvider.TryGetFolderFromPathAsync(Directory.GetCurrentDirectory()),
                 Title = "Open File"
             });
-            
+
             // ReSharper disable ConditionalAccessQualifierIsNonNullableAccordingToAPIContract todo: check why we declare not to be null while returning null
             if (files?.Count > 0)
                 // ReSharper restore ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
@@ -165,7 +165,8 @@ namespace EditNET.Views
             Dispatcher.UIThread.Post(_ => { Editor.TextArea.Focus(); }, null);
         }
 
-        private static async Task MessageBoxHandler(IInteractionContext<MessageBoxModel, MessageBoxResult> interactionContext)
+        private static async Task MessageBoxHandler(
+            IInteractionContext<MessageBoxModel, MessageBoxResult> interactionContext)
         {
             MessageBoxResult result = await MessageBox.ShowDialog(interactionContext.Input.Title,
                 interactionContext.Input.Message,

--- a/src/Edit.NET/Views/EditorView.axaml.cs
+++ b/src/Edit.NET/Views/EditorView.axaml.cs
@@ -125,7 +125,10 @@ namespace EditNET.Views
                     await storageProvider.TryGetFolderFromPathAsync(Directory.GetCurrentDirectory()),
                 Title = "Open File"
             });
+            
+            // ReSharper disable ConditionalAccessQualifierIsNonNullableAccordingToAPIContract todo: check why we declare not to be null while returning null
             if (files?.Count > 0)
+                // ReSharper restore ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
             {
                 IStorageFile file = files[0];
                 interactionContext.SetOutput(file.Path.AbsolutePath);

--- a/src/Edit.NET/Views/EditorView.axaml.cs
+++ b/src/Edit.NET/Views/EditorView.axaml.cs
@@ -125,7 +125,7 @@ namespace EditNET.Views
                     await storageProvider.TryGetFolderFromPathAsync(Directory.GetCurrentDirectory()),
                 Title = "Open File"
             });
-            if (files.Count > 0)
+            if (files?.Count > 0)
             {
                 IStorageFile file = files[0];
                 interactionContext.SetOutput(file.Path.AbsolutePath);
@@ -162,7 +162,7 @@ namespace EditNET.Views
             Dispatcher.UIThread.Post(_ => { Editor.TextArea.Focus(); }, null);
         }
 
-        private static async Task MessageBoxHandler(IInteractionContext<MessageBoxModel, bool> interactionContext)
+        private static async Task MessageBoxHandler(IInteractionContext<MessageBoxModel, MessageBoxResult> interactionContext)
         {
             MessageBoxResult result = await MessageBox.ShowDialog(interactionContext.Input.Title,
                 interactionContext.Input.Message,
@@ -174,7 +174,7 @@ namespace EditNET.Views
                     _ => throw new NotSupportedException("Unsupported MessageBoxButtons value: " +
                                                          interactionContext.Input.Buttons)
                 });
-            interactionContext.SetOutput(result is MessageBoxResult.Ok or MessageBoxResult.Yes);
+            interactionContext.SetOutput(result);
         }
 
         private void UpdateStatus()


### PR DESCRIPTION
2) Bring focus back in editor on Cancel
3) Prevent app crash during File > Open and then Cancel